### PR TITLE
Add Dependent-SUnit-Extensions component to Buoy load spec

### DIFF
--- a/rowan/projects/Buoy.ston
+++ b/rowan/projects/Buoy.ston
@@ -5,6 +5,7 @@ RwLoadSpecificationV2 {
   #revision : 'v8',
   #projectSpecFile : 'rowan/project.ston',
   #componentNames : [
-    'Deployment'
+    'Deployment',
+    'Dependent-SUnit-Extensions'
   ]
 }


### PR DESCRIPTION
This change allows dependent projects wanting to load this components to not clash with this definition